### PR TITLE
add support for third-party s3 compatible storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ For third-party s3 compatible storage like RustFS (https://rustfs.com/) you can 
 endpoint_url=http://localhost:9000
 ```
 
+Some S3 compatible storage need to access for accessing the files the parameter [force_path_style](https://docs.aws.amazon.com/sdk-for-swift/latest/api/awss3/documentation/awss3/endpointparams/forcepathstyle/) set. 
+For this there is an optional parameter (default value=false) that can be set inside your `.data`
+
+```
+force_path_style=true
+```
+
 3. **Installation from crates.io**:
     - Ensure you have Rust and `cargo` installed.
     - Install with cargo

--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ productivity with S3 services.
     - Add as many configurations under `creds` directory (inside your `.data` directory specified with `S3TUI_DATA` env variable)
     - The file should look like the one below:
    
-```bash
+```
 access_key=YOUR_ACCESS_KEY
 secret_key=YOUR_SECRET_KEY
 default_region=eu-west-1
 ```
 Make sure there is a new line at the end and there are no leading spaces on the lines.
+
+For third-party s3 compatible storage like RustFS (https://rustfs.com/) you can add:
+```
+endpoint_url=http://localhost:9000
+```
 
 3. **Installation from crates.io**:
     - Ensure you have Rust and `cargo` installed.

--- a/src/components/s3_creds_page.rs
+++ b/src/components/s3_creds_page.rs
@@ -207,6 +207,7 @@ mod tests {
             access_key: "accessKey".to_string(),
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
+            endpoint_url: None,
             selected: true,
         };
         let state = State::new(vec![creds]);
@@ -223,6 +224,7 @@ mod tests {
             access_key: "accessKey".to_string(),
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
+            endpoint_url: None,
             selected: true,
         };
         let state = State::new(vec![creds.clone()]);
@@ -259,6 +261,7 @@ mod tests {
             access_key: "accessKey".to_string(),
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
+            endpoint_url: None,
             selected: true,
         };
         let state = State::new(vec![creds.clone()]);
@@ -276,6 +279,7 @@ mod tests {
             access_key: "accessKey".to_string(),
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
+            endpoint_url: None,
             selected: false,
         };
         let state = State::new(vec![creds.clone()]);

--- a/src/components/s3_creds_page.rs
+++ b/src/components/s3_creds_page.rs
@@ -208,6 +208,7 @@ mod tests {
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
             endpoint_url: None,
+            force_path_style: false,
             selected: true,
         };
         let state = State::new(vec![creds]);
@@ -225,6 +226,7 @@ mod tests {
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
             endpoint_url: None,
+            force_path_style: false,
             selected: true,
         };
         let state = State::new(vec![creds.clone()]);
@@ -262,6 +264,7 @@ mod tests {
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
             endpoint_url: None,
+            force_path_style: false,
             selected: true,
         };
         let state = State::new(vec![creds.clone()]);
@@ -280,6 +283,7 @@ mod tests {
             secret_key: "secretKey".to_string(),
             default_region: "eu-north-1".to_string(),
             endpoint_url: None,
+            force_path_style: false,
             selected: false,
         };
         let state = State::new(vec![creds.clone()]);

--- a/src/model/s3_selected_item.rs
+++ b/src/model/s3_selected_item.rs
@@ -103,6 +103,7 @@ mod tests {
             access_key: "abc".into(),
             secret_key: "abc".into(),
             default_region: "abc".into(),
+            endpoint_url: None,
             selected: true,
         };
         let destination_dir = "/".into();
@@ -153,6 +154,7 @@ mod tests {
             access_key: "abc".into(),
             secret_key: "abc".into(),
             default_region: "abc".into(),
+            endpoint_url: None,
             selected: true,
         };
         let destination_dir = "/".into();

--- a/src/model/s3_selected_item.rs
+++ b/src/model/s3_selected_item.rs
@@ -104,6 +104,7 @@ mod tests {
             secret_key: "abc".into(),
             default_region: "abc".into(),
             endpoint_url: None,
+            force_path_style: false,
             selected: true,
         };
         let destination_dir = "/".into();
@@ -155,6 +156,7 @@ mod tests {
             secret_key: "abc".into(),
             default_region: "abc".into(),
             endpoint_url: None,
+            force_path_style: false,
             selected: true,
         };
         let destination_dir = "/".into();

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -371,6 +371,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
+                endpoint_url: None
             },
             FileCredential {
                 name: "Azure".into(),
@@ -378,6 +379,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: true,
+                endpoint_url: None
             },
         ];
         let state = State::new(creds.clone());
@@ -393,6 +395,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
+                endpoint_url: None
             },
             FileCredential {
                 name: "Azure".into(),
@@ -400,6 +403,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
+                endpoint_url: None
             },
         ];
         let state = State::new(creds.clone());
@@ -415,6 +419,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: true,
+                endpoint_url: None
             },
             FileCredential {
                 name: "Azure".into(),
@@ -422,6 +427,7 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
+                endpoint_url: None
             },
         ];
         let mut state = State::new(creds.clone());

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -371,7 +371,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style: false
             },
             FileCredential {
                 name: "Azure".into(),
@@ -379,7 +380,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: true,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style: false
             },
         ];
         let state = State::new(creds.clone());
@@ -395,7 +397,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style: false
             },
             FileCredential {
                 name: "Azure".into(),
@@ -403,7 +406,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style: false
             },
         ];
         let state = State::new(creds.clone());
@@ -419,7 +423,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: true,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style:  false
             },
             FileCredential {
                 name: "Azure".into(),
@@ -427,7 +432,8 @@ mod tests {
                 secret_key: "".to_string(),
                 default_region: "".to_string(),
                 selected: false,
-                endpoint_url: None
+                endpoint_url: None,
+                force_path_style: false
             },
         ];
         let mut state = State::new(creds.clone());


### PR DESCRIPTION
Linked to Issue: https://github.com/softberries/s3tui/issues/12

Adding support for local S3 Instances like RustFS. Adding a new optional parameter: 
endpoint_url=http://localhost:9000

to define the URL address of the AWS-S3 compatible storage. 