### PR TITLE
fix: handle empty bucket regions in S3-compatible storage

### DIFF
--- a/src/services/s3_data_fetcher.rs
+++ b/src/services/s3_data_fetcher.rs
@@ -1167,8 +1167,7 @@ impl S3DataFetcher {
             self.get_s3_client(None).await
         };
         
-        let client_with_location = client;
-        let mut response = client_with_location
+        let mut response = client
             .list_objects_v2()
             .delimiter("/")
             .set_prefix(prefix)

--- a/src/services/s3_data_fetcher.rs
+++ b/src/services/s3_data_fetcher.rs
@@ -1133,18 +1133,41 @@ impl S3DataFetcher {
         prefix: Option<String>,
     ) -> eyre::Result<Vec<S3DataItem>> {
         let mut all_objects = Vec::new();
-        let location = self.get_bucket_location(bucket).await?;
-        let creds = self.credentials.clone();
-        let temp_file_creds = FileCredential {
-            name: "temp".to_string(),
-            access_key: creds.access_key_id().to_string(),
-            secret_key: creds.secret_access_key().to_string(),
-            default_region: location.clone(),
-            endpoint_url: self.endpoint_url.clone(),
-            force_path_style: self.force_path_style,
-            selected: false,
+        // Try to get bucket location, but fall back to default region if it fails or returns empty
+        let location = match self.get_bucket_location(bucket).await {
+            Ok(loc) if !loc.is_empty() => {
+                tracing::debug!("Bucket '{}' location: {}", bucket, loc);
+                loc
+            }
+            Ok(loc) => {
+                tracing::warn!("Bucket '{}' returned empty location, using default region '{}'", bucket, self.default_region);
+                self.default_region.clone()
+            }
+            Err(e) => {
+                tracing::warn!("Failed to get bucket location for '{}', using default region '{}': {:?}", bucket, self.default_region, e);
+                self.default_region.clone()
+            }
         };
-        let client_with_location = self.get_s3_client(Some(temp_file_creds)).await;
+        
+        // Only create a new client if the location is different from default
+        let client = if location != self.default_region {
+            let creds = self.credentials.clone();
+            let temp_file_creds = FileCredential {
+                name: "temp".to_string(),
+                access_key: creds.access_key_id().to_string(),
+                secret_key: creds.secret_access_key().to_string(),
+                default_region: location.clone(),
+                endpoint_url: self.endpoint_url.clone(),
+                force_path_style: self.force_path_style,
+                selected: false,
+            };
+            self.get_s3_client(Some(temp_file_creds)).await
+        } else {
+            // Use the existing client for better performance
+            self.get_s3_client(None).await
+        };
+        
+        let client_with_location = client;
         let mut response = client_with_location
             .list_objects_v2()
             .delimiter("/")


### PR DESCRIPTION
## Problem

When using S3-compatible storage like OpenStack Swift with S3 middleware (tested with Infomaniak Swiss Backup), the GetBucketLocation API returns an empty region string instead of a valid region like us-east-1. This causes AuthorizationHeaderMalformed errors when trying to list bucket contents, as the AWS SDK uses the empty region in the signature.

## Error
```
AuthorizationHeaderMalformed: The authorization header is malformed; the region \'\' is wrong; expecting \'us-east-1\'
```

## Solution

This PR fixes the issue by:

1. **Gracefully handling empty regions**: When GetBucketLocation returns an empty string, fall back to the default region from configuration.
2. **Handling API failures**: If GetBucketLocation fails entirely, also fall back to the default region with proper logging.
3. **Performance optimization**: Only create a new S3 client when the bucket region differs from the default region, reducing unnecessary client creation.

## Changes

- Modified list_objects() in src/services/s3_data_fetcher.rs
- Added comprehensive error handling for GetBucketLocation failures
- Added fallback to default region when location is empty
- Optimized client creation logic

## Testing

Tested with:
- Infomaniak Swiss Backup (OpenStack Swift with S3 middleware)
- Buckets: ochaze, test
- Result: Buckets now list contents correctly instead of appearing empty

## Related

Fixes compatibility issues with S3-compatible storage providers that do not properly implement GetBucketLocation or return empty regions.