### PR TITLE
Specify a custom credentials file path with the --creds-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ productivity with S3 services.
 - **Environment Configuration**: Customize settings via environment variables or utilize default settings compliant with
   the XDG Base Directory Specification.
 - **Error Handling**: Integrated `color_eyre` panic hook for clear and colorized error reporting.
-- **Custom Config Path**: Specify a custom credentials file path with the `--creds-file` flag, overriding the default `creds` directory lookup.
+- **Custom Credentials Path**: Specify a custom credentials file path with the `--creds-file` flag, overriding the default `creds` directory lookup.
 - **Version Information**: Quickly view the application version with the `--version` command.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ productivity with S3 services.
 - **Environment Configuration**: Customize settings via environment variables or utilize default settings compliant with
   the XDG Base Directory Specification.
 - **Error Handling**: Integrated `color_eyre` panic hook for clear and colorized error reporting.
+- **Custom Config Path**: Specify a custom credentials file path with the `--creds-file` flag, overriding the default `creds` directory lookup.
 - **Version Information**: Quickly view the application version with the `--version` command.
 
 ## Setup
@@ -143,6 +144,10 @@ The `force_path_style` parameter controls URL formatting:
 - Navigate to the project directory and run:
 ```bash
 ./target/release/s3tui
+```
+- You can also specify a custom credentials file path using the `--creds-file` flag:
+```bash
+s3tui --creds-file /path/to/credentials
 ```
 
 ## Logs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,12 @@
+use std::path::PathBuf;
 use clap::Parser;
 
 use crate::utils::version;
 
 #[derive(Parser, Debug)]
 #[command(author, version = version(), about)]
-pub struct Cli {}
+pub struct Cli {
+    /// Path to the credentials file
+    #[arg(long)]
+    pub creds_file: Option<PathBuf>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,12 +33,12 @@ use color_eyre::eyre;
 async fn main() -> eyre::Result<()> {
     initialize_logging()?;
     initialize_panic_handler()?;
-    let _args = Cli::parse();
+    let args = Cli::parse();
     let (terminator, mut interrupt_rx) = create_termination();
     let (state_store, state_rx) = StateStore::new();
     let (ui_manager, action_rx) = UiManager::new();
 
-    if let Ok(creds) = file_credentials::load_credentials() {
+    if let Ok(creds) = file_credentials::load_credentials(args.creds_file) {
         if !creds.is_empty() {
             tokio::try_join!(
                 state_store.main_loop(terminator, action_rx, interrupt_rx.resubscribe(), creds),

--- a/src/settings/file_credentials.rs
+++ b/src/settings/file_credentials.rs
@@ -73,8 +73,8 @@ pub fn load_credentials(creds_file: Option<PathBuf>) -> eyre::Result<Vec<FileCre
     }
 }
 
-fn load_credentials_from_file(dir_path: &Path) -> eyre::Result<Vec<FileCredential>> {
-    Ok(vec![FileCredential::try_parse_file(dir_path, true)?])
+fn load_credentials_from_file(file_path: &Path) -> eyre::Result<Vec<FileCredential>> {
+    Ok(vec![FileCredential::try_parse_file(file_path, true)?])
 }
 
 fn load_credentials_from_dir(dir_path: &Path) -> eyre::Result<Vec<FileCredential>> {


### PR DESCRIPTION
Hello,

This PR adds a small feature that allows specifying the path to the credentials file (`--config`).
This is my first PR and I’m quite new to Rust, so please be kind 🙂
